### PR TITLE
Switch paths to deps

### DIFF
--- a/components/sms-jp/test/greenlabs/sms/interface_test.clj
+++ b/components/sms-jp/test/greenlabs/sms/interface_test.clj
@@ -3,6 +3,7 @@
             [greenlabs.sms.interface :as sms]))
 
 (deftest send-verification-code-test
+  (println "sms-jp test")
   (testing "인증 메시지 전송"
     (is (= "🇯🇵 認証コードは123456です。" (sms/send-verification-code "010-9999-0000" 123456)))))
 

--- a/components/sms/test/greenlabs/sms/interface_test.clj
+++ b/components/sms/test/greenlabs/sms/interface_test.clj
@@ -4,6 +4,7 @@
 
 
 (deftest send-verification-code-test
+  (println "sms test")
   (testing "인증 메시지 전송"
     (is (= "🇰🇷 인증 번호는 123456 입니다." (sms/send-verification-code "010-9999-0000" 123456)))))
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,27 +1,18 @@
 {:aliases {:dev    {:extra-paths ["development/src"
-                                  "development/resources"
-                                  "bases/rest-api/src"
-                                  "bases/rest-api/resources"
-                                  "components/weather/src"
-                                  "components/weather/resources"
-                                  "components/user/src"
-                                  "components/user/resources"]
-                    :extra-deps  {info.sunng/ring-jetty9-adapter {:mvn/version "0.18.1"}
-                                  metosin/reitit                 {:mvn/version "0.5.18"}}}
+                                  "development/resources"]
+                    :extra-deps  {poly/rest-api {:local/root "bases/rest-api"}
+                                  poly/weather  {:local/root "components/weather"}
+                                  poly/user     {:local/root "components/user"}}}
 
-           :+korea {:extra-paths ["components/sms/src"
-                                  "components/sms/test"]
-                    :extra-deps  {poly/rest-api {:local/root "projects/farm-morning"}}}
+           :+korea {:extra-paths ["components/sms/test"]
+                    :extra-deps  {poly/sms {:local/root "components/sms"}}}
 
-           :+japan {:extra-paths ["components/sms-jp/src"
-                                  "components/sms-jp/test"]
-                    :extra-deps  {poly/rest-api {:local/root "projects/farm-morning-jp"}}}
+           :+japan {:extra-paths ["components/sms-jp/test"]
+                    :extra-deps  {poly/sms {:local/root "components/sms-jp"}}}
 
            :test   {:extra-paths ["bases/rest-api/test"
                                   "components/user/test"
-                                  "components/weather/test"
-                                  "projects/farm-morning/test"
-                                  "projects/farm-morning-jp/test"]}
+                                  "components/weather/test"]}
 
            :poly   {:main-opts  ["-m" "polylith.clj.core.poly-cli.core"]
                     :extra-deps {polyfy/polylith {:git/url   "https://github.com/polyfy/polylith"


### PR DESCRIPTION
Hi Jungin,

These changes seem to get everything working for me:

* `poly test :all` -- runs the `farm-morning` and `farm-morning-jp` project tests successfully
* `poly test :all :dev` -- runs those + the development project with the default profile (`korea`)
* `poly test :all :dev +japan` -- runs those + the development project with the `japan` profile
* `clj -M:dev:+korea` -- starts a REPL with the default profile and I can `(require 'greenlabs.rest-api.core)` successfully
* `clj -M:dev:+japan` -- starts a REPL with the `japan` profile and I can `(require 'greenlabs.rest-api.core)` successfully

We can discuss more in that thread in Slack.